### PR TITLE
Add option to only track authed sessions

### DIFF
--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -12,6 +12,7 @@ import unittest
 
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
+from django.contrib.auth.models import User, AnonymousUser
 from django.contrib.sessions.middleware import SessionMiddleware
 
 from restrictedsessions import middleware
@@ -125,9 +126,22 @@ class TestRestrictedsessionsMiddleware(unittest.TestCase):
         self.request.META['HTTP_USER_AGENT'] = 'test-ua2'
         self.assertTrue(self.middleware.process_request(self.request) is None)
 
+    @override_settings(RESTRICTEDSESSIONS_RESTRICT_UA=True)
+    def test_only_authed_users(self):
+        self.add_session_to_request()
+        self.request.user = AnonymousUser()
+        self.assertIsNone(self.middleware.process_request(self.request))
+
+        self.request.user = User(username='test')
+        self.assertIsNone(self.middleware.process_request(self.request))
+        self._remote_addr_test(session_ip='127.0.0.1', valid='127.0.0.1',
+                               invalid='127.0.0.2')
+        self.assertIsInstance(self.request.user, AnonymousUser)
+
     def add_session_to_request(self):
         middleware = SessionMiddleware()
         middleware.process_request(self.request)
         self.request.session.save()
         # Trigger saving the session
         self.request.session['foo'] = 'foo'
+

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -102,7 +102,7 @@ class TestRestrictedsessionsMiddleware(unittest.TestCase):
         if invalid:
             self.request.session['canary'] = 'canary'
             self.request.META['REMOTE_ADDR'] = invalid
-            self.assertEqual(self.middleware.process_request(self.request).status_code, 400)
+            self.assertIsNone(self.middleware.process_request(self.request))
             self.assertFalse('canary' in self.request.session)
 
     def test_validates_ua(self):
@@ -112,7 +112,7 @@ class TestRestrictedsessionsMiddleware(unittest.TestCase):
         self.assertTrue(self.middleware.process_request(self.request) is None)
 
         self.request.META['HTTP_USER_AGENT'] = 'test-ua2'
-        self.assertEqual(self.middleware.process_request(self.request).status_code, 400)
+        self.assertIsNone(self.middleware.process_request(self.request))
 
     @override_settings(RESTRICTEDSESSIONS_RESTRICT_IP=False)
     def test_disable_ip_validation(self):


### PR DESCRIPTION
If `RESTRICTEDSESSIONS_AUTHED_ONLY`, expect the auth middleware to set up a user object on the request. This user will be tested as an authenticated user and tracked with normal UA and IP tests. Otherwise, the middleware disregards anonymous users, resulting in less accumulated session data.

User sessions change on login/logout, so if a session for an anonymous user is hijacked, that session won't be updated to an authenticated user session.
